### PR TITLE
REST API Authentication and Rate Limiting

### DIFF
--- a/src/omi/auth.py
+++ b/src/omi/auth.py
@@ -1,0 +1,316 @@
+"""
+API Key Authentication and Management for OMI REST API.
+
+Provides secure API key generation, storage, validation, and revocation.
+Keys are hashed with SHA-256 before storage (plaintext never persisted).
+
+Usage:
+    manager = APIKeyManager(db_path)
+    api_key = manager.generate_key("my-app", rate_limit=100)
+    is_valid = manager.validate_key(api_key)
+    manager.revoke_key("my-app")
+"""
+
+import sqlite3
+import hashlib
+import secrets
+import threading
+from pathlib import Path
+from datetime import datetime
+from typing import Optional, List, Dict, Any
+from dataclasses import dataclass
+
+
+@dataclass
+class APIKey:
+    """Represents an API key with metadata."""
+    id: str
+    name: str
+    key_hash: str
+    rate_limit: int
+    created_at: datetime
+    last_used: Optional[datetime] = None
+    revoked: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "key_hash": self.key_hash,
+            "rate_limit": self.rate_limit,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "last_used": self.last_used.isoformat() if self.last_used else None,
+            "revoked": self.revoked
+        }
+
+
+class APIKeyManager:
+    """
+    Manages API keys for authentication.
+
+    Features:
+    - Secure key generation using secrets.token_urlsafe
+    - SHA-256 hashing (plaintext keys never stored)
+    - SQLite storage with WAL mode for concurrency
+    - Per-key rate limiting configuration
+    - Key revocation support
+    - Thread-safe operations
+    """
+
+    def __init__(self, db_path: Path, enable_wal: bool = True):
+        """
+        Initialize API Key Manager.
+
+        Args:
+            db_path: Path to SQLite database file (can be shared with GraphPalace)
+            enable_wal: Enable WAL mode for concurrent writes (default: True)
+        """
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._enable_wal = enable_wal
+
+        # Create persistent connection
+        self._conn = sqlite3.connect(
+            self.db_path,
+            check_same_thread=False,
+            isolation_level=None,
+            timeout=30.0
+        )
+        self._conn.row_factory = sqlite3.Row
+
+        # Thread lock for serializing database operations
+        self._db_lock = threading.Lock()
+
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initialize database schema with indexes."""
+        with self._db_lock:
+            # Enable WAL mode for concurrent writes
+            if self._enable_wal:
+                self._conn.execute("PRAGMA journal_mode=WAL")
+
+            # Foreign key constraints
+            self._conn.execute("PRAGMA foreign_keys=ON")
+
+            # Create api_keys table
+            self._conn.executescript("""
+                CREATE TABLE IF NOT EXISTS api_keys (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    key_hash TEXT NOT NULL UNIQUE,
+                    rate_limit INTEGER NOT NULL DEFAULT 100,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    last_used TIMESTAMP,
+                    revoked INTEGER DEFAULT 0 CHECK(revoked IN (0, 1))
+                );
+
+                -- Indexes for performance
+                CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash);
+                CREATE INDEX IF NOT EXISTS idx_api_keys_name ON api_keys(name);
+                CREATE INDEX IF NOT EXISTS idx_api_keys_revoked ON api_keys(revoked);
+            """)
+
+    def _hash_key(self, api_key: str) -> str:
+        """
+        Hash an API key using SHA-256.
+
+        Args:
+            api_key: The plaintext API key
+
+        Returns:
+            str: Hexadecimal SHA-256 hash
+        """
+        return hashlib.sha256(api_key.encode()).hexdigest()
+
+    def generate_key(self, name: str, rate_limit: int = 100) -> str:
+        """
+        Generate a new API key.
+
+        Args:
+            name: Human-readable name for the key (must be unique)
+            rate_limit: Requests per minute allowed (default: 100)
+
+        Returns:
+            str: The generated API key (only shown once, not stored)
+
+        Raises:
+            ValueError: If a key with this name already exists
+        """
+        # Generate secure random key (32 bytes = 43 chars in base64)
+        api_key = secrets.token_urlsafe(32)
+        key_hash = self._hash_key(api_key)
+        key_id = secrets.token_urlsafe(16)
+
+        with self._db_lock:
+            try:
+                self._conn.execute(
+                    """
+                    INSERT INTO api_keys (id, name, key_hash, rate_limit, created_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (key_id, name, key_hash, rate_limit, datetime.now().isoformat())
+                )
+            except sqlite3.IntegrityError as e:
+                if "name" in str(e).lower():
+                    raise ValueError(f"API key with name '{name}' already exists")
+                elif "key_hash" in str(e).lower():
+                    # Extremely unlikely, but handle hash collision
+                    raise ValueError("Key generation collision (retry)")
+                raise
+
+        return api_key
+
+    def validate_key(self, api_key: str) -> Optional[APIKey]:
+        """
+        Validate an API key and return its metadata.
+
+        Args:
+            api_key: The API key to validate
+
+        Returns:
+            APIKey object if valid and not revoked, None otherwise
+        """
+        key_hash = self._hash_key(api_key)
+
+        with self._db_lock:
+            row = self._conn.execute(
+                """
+                SELECT id, name, key_hash, rate_limit, created_at, last_used, revoked
+                FROM api_keys
+                WHERE key_hash = ? AND revoked = 0
+                """,
+                (key_hash,)
+            ).fetchone()
+
+            if row is None:
+                return None
+
+            # Update last_used timestamp
+            self._conn.execute(
+                "UPDATE api_keys SET last_used = ? WHERE key_hash = ?",
+                (datetime.now().isoformat(), key_hash)
+            )
+
+            return APIKey(
+                id=row["id"],
+                name=row["name"],
+                key_hash=row["key_hash"],
+                rate_limit=row["rate_limit"],
+                created_at=datetime.fromisoformat(row["created_at"]),
+                last_used=datetime.fromisoformat(row["last_used"]) if row["last_used"] else None,
+                revoked=bool(row["revoked"])
+            )
+
+    def revoke_key(self, name: Optional[str] = None, api_key: Optional[str] = None) -> bool:
+        """
+        Revoke an API key by name or key value.
+
+        Args:
+            name: Name of the key to revoke
+            api_key: The API key value to revoke
+
+        Returns:
+            bool: True if a key was revoked, False if not found
+
+        Raises:
+            ValueError: If neither name nor api_key is provided
+        """
+        if name is None and api_key is None:
+            raise ValueError("Must provide either name or api_key")
+
+        with self._db_lock:
+            if name is not None:
+                cursor = self._conn.execute(
+                    "UPDATE api_keys SET revoked = 1 WHERE name = ? AND revoked = 0",
+                    (name,)
+                )
+            else:
+                key_hash = self._hash_key(api_key)
+                cursor = self._conn.execute(
+                    "UPDATE api_keys SET revoked = 1 WHERE key_hash = ? AND revoked = 0",
+                    (key_hash,)
+                )
+
+            return cursor.rowcount > 0
+
+    def list_keys(self, include_revoked: bool = False) -> List[APIKey]:
+        """
+        List all API keys.
+
+        Args:
+            include_revoked: Include revoked keys in the list (default: False)
+
+        Returns:
+            List of APIKey objects
+        """
+        with self._db_lock:
+            if include_revoked:
+                rows = self._conn.execute(
+                    """
+                    SELECT id, name, key_hash, rate_limit, created_at, last_used, revoked
+                    FROM api_keys
+                    ORDER BY created_at DESC
+                    """
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """
+                    SELECT id, name, key_hash, rate_limit, created_at, last_used, revoked
+                    FROM api_keys
+                    WHERE revoked = 0
+                    ORDER BY created_at DESC
+                    """
+                ).fetchall()
+
+            return [
+                APIKey(
+                    id=row["id"],
+                    name=row["name"],
+                    key_hash=row["key_hash"],
+                    rate_limit=row["rate_limit"],
+                    created_at=datetime.fromisoformat(row["created_at"]),
+                    last_used=datetime.fromisoformat(row["last_used"]) if row["last_used"] else None,
+                    revoked=bool(row["revoked"])
+                )
+                for row in rows
+            ]
+
+    def get_key_by_name(self, name: str) -> Optional[APIKey]:
+        """
+        Get an API key by its name.
+
+        Args:
+            name: Name of the key
+
+        Returns:
+            APIKey object if found, None otherwise
+        """
+        with self._db_lock:
+            row = self._conn.execute(
+                """
+                SELECT id, name, key_hash, rate_limit, created_at, last_used, revoked
+                FROM api_keys
+                WHERE name = ?
+                """,
+                (name,)
+            ).fetchone()
+
+            if row is None:
+                return None
+
+            return APIKey(
+                id=row["id"],
+                name=row["name"],
+                key_hash=row["key_hash"],
+                rate_limit=row["rate_limit"],
+                created_at=datetime.fromisoformat(row["created_at"]),
+                last_used=datetime.fromisoformat(row["last_used"]) if row["last_used"] else None,
+                revoked=bool(row["revoked"])
+            )
+
+    def close(self) -> None:
+        """Close the database connection."""
+        with self._db_lock:
+            self._conn.close()

--- a/src/omi/cli.py
+++ b/src/omi/cli.py
@@ -169,6 +169,7 @@ security:
   integrity_checks: true
   auto_audit: true
   required_instances: 3
+  default_rate_limit: 100  # Default rate limit for API keys (requests/minute)
 
 session:
   auto_check_interval: 300  # seconds

--- a/src/omi/cli/config.py
+++ b/src/omi/cli/config.py
@@ -115,3 +115,177 @@ def config_show(ctx) -> None:
     content = config_path.read_text()
     echo_normal(click.style("Current configuration:", fg="cyan", bold=True), verbosity)
     echo_quiet(content, verbosity)
+
+
+# API Key Management Commands
+@config_group.group('api-key')
+def api_key_group():
+    """API key management commands."""
+    pass
+
+
+@api_key_group.command('generate')
+@click.option('--name', required=True, help='Name for the API key (must be unique)')
+@click.option('--rate-limit', type=int, default=100, help='Requests per minute (default: 100)')
+@click.pass_context
+def api_key_generate(ctx, name: str, rate_limit: int) -> None:
+    """Generate a new API key.
+
+    Args:
+        --name: Human-readable name for the key (must be unique)
+        --rate-limit: Requests per minute allowed (default: 100)
+
+    Examples:
+        omi config api-key generate --name production-agent
+        omi config api-key generate --name dev-bot --rate-limit 50
+    """
+    from omi.auth import APIKeyManager
+
+    base_path = get_base_path(ctx.obj.get('data_dir'))
+    verbosity = ctx.obj.get('verbosity', 1)
+
+    if not base_path.exists():
+        echo_quiet(click.style("Error: OMI not initialized. Run 'omi init' first.", fg="red"), verbosity)
+        sys.exit(1)
+
+    db_path = base_path / "palace.sqlite"
+
+    try:
+        manager = APIKeyManager(db_path)
+        api_key = manager.generate_key(name, rate_limit=rate_limit)
+
+        echo_normal(click.style("✓ API key generated successfully", fg="green"), verbosity)
+        echo_quiet("", verbosity)
+        echo_quiet(click.style(f"Name: {name}", fg="cyan"), verbosity)
+        echo_quiet(click.style(f"Rate Limit: {rate_limit} requests/minute", fg="cyan"), verbosity)
+        echo_quiet("", verbosity)
+        echo_quiet(click.style("API Key (save this - it won't be shown again):", fg="yellow", bold=True), verbosity)
+        echo_quiet(click.style(api_key, fg="green", bold=True), verbosity)
+        echo_quiet("", verbosity)
+        echo_quiet(click.style("Use this key in requests:", fg="cyan"), verbosity)
+        echo_quiet(f"  Header: X-API-Key: {api_key}", verbosity)
+        echo_quiet(f"  Query param: ?api_key={api_key}", verbosity)
+
+    except ValueError as e:
+        echo_quiet(click.style(f"Error: {e}", fg="red"), verbosity)
+        sys.exit(1)
+    except Exception as e:
+        echo_quiet(click.style(f"Error: Failed to generate API key: {e}", fg="red"), verbosity)
+        sys.exit(1)
+
+
+@api_key_group.command('revoke')
+@click.option('--name', help='Name of the API key to revoke')
+@click.option('--key', help='The API key value to revoke')
+@click.pass_context
+def api_key_revoke(ctx, name: str, key: str) -> None:
+    """Revoke an API key by name or key value.
+
+    Args:
+        --name: Name of the key to revoke
+        --key: The API key value to revoke
+
+    Examples:
+        omi config api-key revoke --name production-agent
+        omi config api-key revoke --key abc123...
+    """
+    from omi.auth import APIKeyManager
+
+    base_path = get_base_path(ctx.obj.get('data_dir'))
+    verbosity = ctx.obj.get('verbosity', 1)
+
+    if not base_path.exists():
+        echo_quiet(click.style("Error: OMI not initialized. Run 'omi init' first.", fg="red"), verbosity)
+        sys.exit(1)
+
+    if name is None and key is None:
+        echo_quiet(click.style("Error: Must provide either --name or --key", fg="red"), verbosity)
+        sys.exit(1)
+
+    db_path = base_path / "palace.sqlite"
+
+    try:
+        manager = APIKeyManager(db_path)
+        revoked = manager.revoke_key(name=name, api_key=key)
+
+        if revoked:
+            identifier = name if name else f"key {key[:16]}..."
+            echo_normal(click.style(f"✓ Revoked API key: {identifier}", fg="green"), verbosity)
+        else:
+            identifier = name if name else "with provided value"
+            echo_quiet(click.style(f"Warning: No active API key found {identifier}", fg="yellow"), verbosity)
+            sys.exit(1)
+
+    except Exception as e:
+        echo_quiet(click.style(f"Error: Failed to revoke API key: {e}", fg="red"), verbosity)
+        sys.exit(1)
+
+
+@api_key_group.command('list')
+@click.option('--include-revoked', is_flag=True, help='Include revoked keys in the list')
+@click.pass_context
+def api_key_list(ctx, include_revoked: bool) -> None:
+    """List all API keys with metadata.
+
+    Args:
+        --include-revoked: Include revoked keys in the list (default: False)
+
+    Examples:
+        omi config api-key list
+        omi config api-key list --include-revoked
+    """
+    from omi.auth import APIKeyManager
+
+    base_path = get_base_path(ctx.obj.get('data_dir'))
+    verbosity = ctx.obj.get('verbosity', 1)
+
+    if not base_path.exists():
+        echo_quiet(click.style("Error: OMI not initialized. Run 'omi init' first.", fg="red"), verbosity)
+        sys.exit(1)
+
+    db_path = base_path / "palace.sqlite"
+
+    try:
+        manager = APIKeyManager(db_path)
+        keys = manager.list_keys(include_revoked=include_revoked)
+
+        if not keys:
+            echo_normal(click.style("No API keys found.", fg="yellow"), verbosity)
+            return
+
+        # Display header
+        status_text = " (including revoked)" if include_revoked else ""
+        echo_normal(click.style(f"API Keys ({len(keys)} found{status_text})", fg="cyan", bold=True), verbosity)
+        echo_quiet("", verbosity)
+
+        # Display each key
+        for api_key in keys:
+            # Key name (with revoked status)
+            status = click.style(" [REVOKED]", fg="red") if api_key.revoked else ""
+            echo_normal(click.style(f"• {api_key.name}", fg="green", bold=True) + status, verbosity)
+
+            # ID
+            echo_quiet(f"  ID: {api_key.id}", verbosity)
+
+            # Rate limit
+            echo_quiet(f"  Rate Limit: {api_key.rate_limit} requests/minute", verbosity)
+
+            # Created
+            created_str = api_key.created_at.strftime('%Y-%m-%d %H:%M:%S') if api_key.created_at else 'N/A'
+            echo_quiet(f"  Created: {created_str}", verbosity)
+
+            # Last used
+            if api_key.last_used:
+                last_used_str = api_key.last_used.strftime('%Y-%m-%d %H:%M:%S')
+                echo_quiet(f"  Last Used: {last_used_str}", verbosity)
+            else:
+                echo_quiet(f"  Last Used: Never", verbosity)
+
+            # Key hash (first 16 chars for reference)
+            echo_quiet(f"  Key Hash: {api_key.key_hash[:16]}...", verbosity)
+
+            echo_quiet("", verbosity)
+
+    except Exception as e:
+        echo_quiet(click.style(f"Error: Failed to list API keys: {e}", fg="red"), verbosity)
+        sys.exit(1)

--- a/src/omi/dashboard_api.py
+++ b/src/omi/dashboard_api.py
@@ -247,7 +247,8 @@ async def get_memories(
     offset: int = Query(default=0, ge=0, description="Number of memories to skip"),
     memory_type: Optional[str] = Query(default=None, description="Filter by memory type (fact, experience, belief, decision)"),
     order_by: str = Query(default="created_at", description="Field to order by (created_at, access_count, last_accessed)"),
-    order_dir: str = Query(default="desc", description="Order direction (asc, desc)")
+    order_dir: str = Query(default="desc", description="Order direction (asc, desc)"),
+    api_key: str = Depends(verify_dashboard_api_key)
 ) -> Dict[str, Any]:
     """
     Retrieve memories with optional filters.
@@ -368,7 +369,8 @@ async def get_edges(
     offset: int = Query(default=0, ge=0, description="Number of edges to skip"),
     edge_type: Optional[str] = Query(default=None, description="Filter by edge type (SUPPORTS, CONTRADICTS, RELATED_TO, DEPENDS_ON, POSTED, DISCUSSED)"),
     order_by: str = Query(default="created_at", description="Field to order by (created_at, strength)"),
-    order_dir: str = Query(default="desc", description="Order direction (asc, desc)")
+    order_dir: str = Query(default="desc", description="Order direction (asc, desc)"),
+    api_key: str = Depends(verify_dashboard_api_key)
 ) -> Dict[str, Any]:
     """
     Retrieve relationship edges with optional filters.
@@ -483,7 +485,8 @@ async def get_beliefs(
     limit: int = Query(default=100, ge=1, le=1000, description="Maximum number of beliefs to return"),
     offset: int = Query(default=0, ge=0, description="Number of beliefs to skip"),
     order_by: str = Query(default="last_updated", description="Field to order by (confidence, created_at, last_updated, evidence_count)"),
-    order_dir: str = Query(default="desc", description="Order direction (asc, desc)")
+    order_dir: str = Query(default="desc", description="Order direction (asc, desc)"),
+    api_key: str = Depends(verify_dashboard_api_key)
 ) -> Dict[str, Any]:
     """
     Retrieve beliefs from the belief network.
@@ -578,7 +581,8 @@ async def get_beliefs(
 
 @router.get("/graph")
 async def get_graph(
-    limit: int = Query(default=100, ge=1, le=1000, description="Maximum number of memories and edges to return")
+    limit: int = Query(default=100, ge=1, le=1000, description="Maximum number of memories and edges to return"),
+    api_key: str = Depends(verify_dashboard_api_key)
 ) -> Dict[str, Any]:
     """
     Retrieve complete graph data (memories + edges) in one call.
@@ -684,7 +688,9 @@ async def get_graph(
 
 
 @router.get("/stats")
-async def get_stats() -> Dict[str, Any]:
+async def get_stats(
+    api_key: str = Depends(verify_dashboard_api_key)
+) -> Dict[str, Any]:
     """
     Get database storage statistics.
 
@@ -747,7 +753,8 @@ async def get_stats() -> Dict[str, Any]:
 async def search_memories(
     q: str = Query(..., description="Search query text", min_length=1),
     limit: int = Query(default=10, ge=1, le=100, description="Maximum number of results to return"),
-    min_relevance: float = Query(default=0.5, ge=0.0, le=1.0, description="Minimum relevance threshold")
+    min_relevance: float = Query(default=0.5, ge=0.0, le=1.0, description="Minimum relevance threshold"),
+    api_key: str = Depends(verify_dashboard_api_key)
 ) -> Dict[str, Any]:
     """
     Semantic search for memories using embeddings.

--- a/src/omi/rest_api.py
+++ b/src/omi/rest_api.py
@@ -588,7 +588,8 @@ async def events_sse(
     event_type: Optional[str] = Query(
         None,
         description="Filter by event type (e.g., 'memory.stored', 'belief.updated'). Omit for all events."
-    )
+    ),
+    api_key: str = Depends(verify_api_key)
 ) -> StreamingResponse:
     """
     Server-Sent Events (SSE) endpoint for real-time event streaming.

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,554 @@
+"""REST API Authentication Tests for OMI
+
+Tests the FastAPI REST API authentication system including:
+1. API key validation (header and query parameter)
+2. Development mode fallbacks
+3. Config-based auth control
+4. Revoked key rejection
+5. Dashboard endpoint authentication
+
+Issue: https://github.com/slapglif/omi/issues/43
+"""
+import pytest
+import tempfile
+import yaml
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+from omi.rest_api import app, get_memory_tools
+from omi.auth import APIKeyManager
+from omi.event_bus import get_event_bus, reset_event_bus
+
+
+@pytest.fixture(autouse=True)
+def reset_bus():
+    """Reset EventBus before each test."""
+    reset_event_bus()
+    yield
+    reset_event_bus()
+
+
+@pytest.fixture
+def temp_data_dir():
+    """Create a temporary directory for test data with .openclaw/omi structure."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create the full .openclaw/omi structure
+        base_path = Path(tmpdir) / '.openclaw' / 'omi'
+        base_path.mkdir(parents=True, exist_ok=True)
+        yield base_path
+
+
+@pytest.fixture
+def client():
+    """Create FastAPI test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_memory_tools():
+    """Mock MemoryTools to avoid actual storage operations."""
+    mock_tools = MagicMock()
+
+    # Mock store method to return a memory ID
+    mock_tools.store.return_value = "mem_test_123"
+
+    # Mock recall method to return sample memories
+    mock_tools.recall.return_value = [
+        {
+            "id": "mem_1",
+            "content": "Test memory 1",
+            "memory_type": "fact",
+            "relevance": 0.95,
+            "created_at": "2024-01-01T00:00:00",
+            "final_score": 0.85
+        }
+    ]
+
+    return mock_tools
+
+
+@pytest.fixture
+def mock_belief_tools():
+    """Mock BeliefTools to avoid actual belief operations."""
+    mock_tools = MagicMock()
+
+    # Mock create_belief method
+    mock_tools.create_belief.return_value = "belief_test_123"
+
+    # Mock update_belief method
+    mock_tools.update_belief.return_value = 0.75
+
+    return mock_tools
+
+
+class TestHeaderAuthentication:
+    """Test API key authentication via X-API-Key header."""
+
+    def test_valid_api_key_in_header_succeeds(self, client, temp_data_dir, mock_memory_tools):
+        """
+        POST /api/v1/store with valid API key in X-API-Key header
+        Assert: Returns 201 with memory_id
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        # Create config with auth enabled
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True,
+                "default_rate_limit": 100
+            }
+        }))
+
+        # Generate API key
+        key_manager = APIKeyManager(db_path)
+        api_key = key_manager.generate_key("test-key", rate_limit=100)
+
+        # Mock Path.home() to return temp directory parent (so .openclaw/omi resolves to temp_data_dir)
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.post(
+                    "/api/v1/store",
+                    json={
+                        "content": "Test memory with auth",
+                        "memory_type": "fact"
+                    },
+                    headers={"X-API-Key": api_key}
+                )
+
+        assert response.status_code == 201
+        assert "memory_id" in response.json()
+
+    def test_invalid_api_key_in_header_returns_401(self, client, temp_data_dir, mock_memory_tools):
+        """
+        POST /api/v1/store with invalid API key in X-API-Key header
+        Assert: Returns 401 with error message
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        # Create config with auth enabled
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True
+            }
+        }))
+
+        # Generate a valid API key (but we'll use an invalid one)
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=100)
+
+        # Mock Path.home() to return temp directory parent
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.post(
+                    "/api/v1/store",
+                    json={
+                        "content": "Test memory",
+                        "memory_type": "fact"
+                    },
+                    headers={"X-API-Key": "invalid_key_12345"}
+                )
+
+        assert response.status_code == 401
+        assert "Invalid or revoked API key" in response.json()["detail"]
+
+    def test_missing_api_key_returns_401(self, client, temp_data_dir, mock_memory_tools):
+        """
+        POST /api/v1/store without API key when auth is required
+        Assert: Returns 401 with helpful error message
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        # Create config with auth enabled
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True
+            }
+        }))
+
+        # Generate an API key (to ensure auth is required)
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=100)
+
+        # Mock Path.home() to return temp directory parent
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.post(
+                    "/api/v1/store",
+                    json={
+                        "content": "Test memory",
+                        "memory_type": "fact"
+                    }
+                )
+
+        assert response.status_code == 401
+        assert "Missing API key" in response.json()["detail"]
+        assert "X-API-Key" in response.json()["detail"]
+
+
+class TestQueryParameterAuthentication:
+    """Test API key authentication via query parameter."""
+
+    def test_valid_api_key_in_query_param_succeeds(self, client, temp_data_dir, mock_memory_tools):
+        """
+        GET /api/v1/recall with valid API key in query parameter
+        Assert: Returns 200 with memories
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        # Create config with auth enabled
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True,
+                "default_rate_limit": 100
+            }
+        }))
+
+        # Generate API key
+        key_manager = APIKeyManager(db_path)
+        api_key = key_manager.generate_key("test-key", rate_limit=100)
+
+        # Mock Path.home() to return temp directory parent
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.get(
+                    f"/api/v1/recall?query=test&api_key={api_key}"
+                )
+
+        assert response.status_code == 200
+        assert "memories" in response.json()
+
+    def test_header_takes_precedence_over_query_param(self, client, temp_data_dir, mock_memory_tools):
+        """
+        POST /api/v1/store with valid header and invalid query param
+        Assert: Returns 201 (header key is used)
+        """
+        # Setup database and API keys
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        # Create config with auth enabled
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True,
+                "default_rate_limit": 100
+            }
+        }))
+
+        # Generate valid API key
+        key_manager = APIKeyManager(db_path)
+        valid_key = key_manager.generate_key("test-key", rate_limit=100)
+        invalid_key = "invalid_key_12345"
+
+        # Mock Path.home() to return temp directory parent
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.post(
+                    f"/api/v1/store?api_key={invalid_key}",
+                    json={
+                        "content": "Test memory",
+                        "memory_type": "fact"
+                    },
+                    headers={"X-API-Key": valid_key}
+                )
+
+        # Should succeed because header key (valid) takes precedence
+        assert response.status_code == 201
+
+
+class TestRevokedKeyRejection:
+    """Test that revoked API keys are rejected."""
+
+    def test_revoked_key_returns_401(self, client, temp_data_dir, mock_memory_tools):
+        """
+        POST /api/v1/store with revoked API key
+        Assert: Returns 401 with error message
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        # Create config with auth enabled
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True
+            }
+        }))
+
+        # Generate two keys: one to keep active, one to revoke
+        # (This prevents fallback to development mode when checking list_keys())
+        key_manager = APIKeyManager(db_path)
+        revoked_key = key_manager.generate_key("revoked-key", rate_limit=100)
+        key_manager.generate_key("active-key", rate_limit=100)  # Keep this one active
+
+        # Now revoke the first key
+        key_manager.revoke_key(name="revoked-key")
+
+        # Mock Path.home() to return temp directory parent
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.post(
+                    "/api/v1/store",
+                    json={
+                        "content": "Test memory",
+                        "memory_type": "fact"
+                    },
+                    headers={"X-API-Key": revoked_key}
+                )
+
+        assert response.status_code == 401
+        assert "Invalid or revoked API key" in response.json()["detail"]
+
+
+class TestDevelopmentMode:
+    """Test development mode fallback scenarios."""
+
+    def test_auth_disabled_in_config_allows_all_requests(self, client, temp_data_dir, mock_memory_tools):
+        """
+        POST /api/v1/store with auth_required=false in config
+        Assert: Returns 201 without API key
+        """
+        # Setup database and config
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        # Create config with auth disabled
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": False
+            }
+        }))
+
+        # Create database (even with keys, auth should be disabled)
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=100)
+
+        # Mock Path.home() to return temp directory parent
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.post(
+                    "/api/v1/store",
+                    json={
+                        "content": "Test memory",
+                        "memory_type": "fact"
+                    }
+                )
+
+        assert response.status_code == 201
+
+    def test_no_database_allows_all_requests(self, client, temp_data_dir, mock_memory_tools):
+        """
+        POST /api/v1/store when database doesn't exist
+        Assert: Returns 201 without API key (development mode)
+        """
+        # Setup config but no database
+        config_path = temp_data_dir / "config.yaml"
+
+        # Create config with auth enabled
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True
+            }
+        }))
+
+        # Do NOT create database - this triggers development mode
+
+        # Mock Path.home() to return temp directory parent
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.post(
+                    "/api/v1/store",
+                    json={
+                        "content": "Test memory",
+                        "memory_type": "fact"
+                    }
+                )
+
+        assert response.status_code == 201
+
+    def test_no_api_keys_configured_allows_all_requests(self, client, temp_data_dir, mock_memory_tools):
+        """
+        POST /api/v1/store when no API keys are configured
+        Assert: Returns 201 without API key (development mode)
+        """
+        # Setup database but no API keys
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        # Create config with auth enabled
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True
+            }
+        }))
+
+        # Create database but don't add any API keys
+        key_manager = APIKeyManager(db_path)
+        assert len(key_manager.list_keys()) == 0
+
+        # Mock Path.home() to return temp directory parent
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.post(
+                    "/api/v1/store",
+                    json={
+                        "content": "Test memory",
+                        "memory_type": "fact"
+                    }
+                )
+
+        assert response.status_code == 201
+
+
+class TestMultipleEndpoints:
+    """Test authentication across different endpoint types."""
+
+    def test_recall_endpoint_requires_auth(self, client, temp_data_dir, mock_memory_tools):
+        """
+        GET /api/v1/recall without API key when auth is required
+        Assert: Returns 401
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {"auth_required": True}
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=100)
+
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                response = client.get("/api/v1/recall?query=test")
+
+        assert response.status_code == 401
+
+    def test_beliefs_endpoint_requires_auth(self, client, temp_data_dir, mock_belief_tools):
+        """
+        POST /api/v1/beliefs without API key when auth is required
+        Assert: Returns 401
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {"auth_required": True}
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=100)
+
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_belief_tools', return_value=mock_belief_tools):
+                response = client.post(
+                    "/api/v1/beliefs",
+                    json={"content": "Test belief", "initial_confidence": 0.5}
+                )
+
+        assert response.status_code == 401
+
+    def test_sessions_endpoint_requires_auth(self, client, temp_data_dir):
+        """
+        POST /api/v1/sessions/start without API key when auth is required
+        Assert: Returns 401
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {"auth_required": True}
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=100)
+
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            response = client.post(
+                "/api/v1/sessions/start",
+                json={"session_id": "test-session"}
+            )
+
+        assert response.status_code == 401
+
+    def test_events_endpoint_requires_auth(self, client, temp_data_dir):
+        """
+        GET /api/v1/events without API key when auth is required
+        Assert: Returns 401
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {"auth_required": True}
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=100)
+
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            # Try to connect to SSE endpoint
+            # Note: This will return 401 before connection is established
+            response = client.get("/api/v1/events")
+
+        assert response.status_code == 401
+
+
+class TestUnauthenticatedEndpoints:
+    """Test that certain endpoints remain unauthenticated."""
+
+    def test_root_endpoint_is_unauthenticated(self, client, temp_data_dir):
+        """
+        GET / (root endpoint)
+        Assert: Returns 200 without API key
+        """
+        # Setup database and API key (auth required)
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {"auth_required": True}
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=100)
+
+        # Root endpoint should work without auth
+        response = client.get("/")
+
+        assert response.status_code == 200
+        assert "service" in response.json()
+
+    def test_health_endpoint_is_unauthenticated(self, client, temp_data_dir):
+        """
+        GET /health
+        Assert: Returns 200 without API key
+        """
+        # Setup database and API key (auth required)
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {"auth_required": True}
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=100)
+
+        # Health endpoint should work without auth
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "healthy"

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,0 +1,521 @@
+"""REST API Rate Limiting Tests for OMI
+
+Tests the FastAPI REST API rate limiting system including:
+1. Requests under limit succeed
+2. Request over limit returns 429 with Retry-After header
+3. Rate limit resets after window expires
+4. Different API keys have separate rate limits
+5. Custom rate limits per key work correctly
+6. Rate limiter sliding window behavior
+
+Issue: https://github.com/slapglif/omi/issues/43
+"""
+import pytest
+import time
+import tempfile
+import yaml
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+from omi.rest_api import app, rate_limiter
+from omi.auth import APIKeyManager, RateLimiter
+from omi.event_bus import get_event_bus, reset_event_bus
+
+
+@pytest.fixture(autouse=True)
+def reset_bus():
+    """Reset EventBus before each test."""
+    reset_event_bus()
+    yield
+    reset_event_bus()
+
+
+@pytest.fixture
+def temp_data_dir():
+    """Create a temporary directory for test data with .openclaw/omi structure."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create the full .openclaw/omi structure
+        base_path = Path(tmpdir) / '.openclaw' / 'omi'
+        base_path.mkdir(parents=True, exist_ok=True)
+        yield base_path
+
+
+@pytest.fixture
+def client():
+    """Create FastAPI test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_memory_tools():
+    """Mock MemoryTools to avoid actual storage operations."""
+    mock_tools = MagicMock()
+
+    # Mock store method to return a memory ID
+    mock_tools.store.return_value = "mem_test_123"
+
+    # Mock recall method to return sample memories
+    mock_tools.recall.return_value = [
+        {
+            "id": "mem_1",
+            "content": "Test memory 1",
+            "memory_type": "fact",
+            "relevance": 0.95,
+            "created_at": "2024-01-01T00:00:00",
+            "final_score": 0.85
+        }
+    ]
+
+    return mock_tools
+
+
+@pytest.fixture
+def reset_rate_limiter():
+    """Reset the global rate limiter before and after each test."""
+    rate_limiter.reset()
+    yield
+    rate_limiter.reset()
+
+
+class TestRateLimiterUnit:
+    """Test RateLimiter class directly (unit tests)."""
+
+    def test_requests_under_limit_succeed(self):
+        """
+        Make requests under the rate limit
+        Assert: All requests are allowed
+        """
+        limiter = RateLimiter(window_seconds=60)
+        api_key = "test_key_123"
+        limit = 10
+
+        # Make 10 requests (all should succeed)
+        for i in range(limit):
+            allowed, retry_after = limiter.check_rate_limit(api_key, limit)
+            assert allowed is True, f"Request {i+1} should be allowed"
+            assert retry_after == 0, f"retry_after should be 0 for allowed request {i+1}"
+
+    def test_request_over_limit_returns_false_with_retry_after(self):
+        """
+        Make requests exceeding the rate limit
+        Assert: Excess requests are denied with retry_after > 0
+        """
+        limiter = RateLimiter(window_seconds=60)
+        api_key = "test_key_123"
+        limit = 5
+
+        # Make 5 requests (all should succeed)
+        for i in range(limit):
+            allowed, retry_after = limiter.check_rate_limit(api_key, limit)
+            assert allowed is True
+
+        # 6th request should be denied
+        allowed, retry_after = limiter.check_rate_limit(api_key, limit)
+        assert allowed is False
+        assert retry_after > 0
+        assert retry_after <= 60  # Should be within the window
+
+    def test_rate_limit_resets_after_window(self):
+        """
+        Make requests, wait for window to expire, make more requests
+        Assert: Requests succeed after window expires
+        """
+        limiter = RateLimiter(window_seconds=2)  # Short window for testing
+        api_key = "test_key_123"
+        limit = 3
+
+        # Make 3 requests (all should succeed)
+        for i in range(limit):
+            allowed, retry_after = limiter.check_rate_limit(api_key, limit)
+            assert allowed is True
+
+        # 4th request should be denied
+        allowed, retry_after = limiter.check_rate_limit(api_key, limit)
+        assert allowed is False
+
+        # Wait for window to expire
+        time.sleep(2.1)
+
+        # New request should succeed (old timestamps expired)
+        allowed, retry_after = limiter.check_rate_limit(api_key, limit)
+        assert allowed is True
+        assert retry_after == 0
+
+    def test_different_api_keys_have_separate_limits(self):
+        """
+        Make requests with different API keys
+        Assert: Each API key has its own rate limit tracking
+        """
+        limiter = RateLimiter(window_seconds=60)
+        api_key_1 = "test_key_1"
+        api_key_2 = "test_key_2"
+        limit = 5
+
+        # Exhaust limit for key 1
+        for i in range(limit):
+            allowed, _ = limiter.check_rate_limit(api_key_1, limit)
+            assert allowed is True
+
+        # Key 1 should be limited
+        allowed, retry_after = limiter.check_rate_limit(api_key_1, limit)
+        assert allowed is False
+        assert retry_after > 0
+
+        # Key 2 should still have full limit available
+        for i in range(limit):
+            allowed, _ = limiter.check_rate_limit(api_key_2, limit)
+            assert allowed is True, f"Key 2 request {i+1} should be allowed"
+
+    def test_custom_rate_limits_per_key_work_correctly(self):
+        """
+        Make requests with different rate limits for different keys
+        Assert: Each key respects its configured limit
+        """
+        limiter = RateLimiter(window_seconds=60)
+        api_key_low = "test_key_low_limit"
+        api_key_high = "test_key_high_limit"
+        low_limit = 3
+        high_limit = 10
+
+        # Low limit key should be limited after 3 requests
+        for i in range(low_limit):
+            allowed, _ = limiter.check_rate_limit(api_key_low, low_limit)
+            assert allowed is True
+
+        allowed, _ = limiter.check_rate_limit(api_key_low, low_limit)
+        assert allowed is False
+
+        # High limit key should still accept requests
+        for i in range(high_limit):
+            allowed, _ = limiter.check_rate_limit(api_key_high, high_limit)
+            assert allowed is True
+
+        allowed, _ = limiter.check_rate_limit(api_key_high, high_limit)
+        assert allowed is False
+
+    def test_get_remaining_returns_correct_count(self):
+        """
+        Make requests and check remaining count
+        Assert: get_remaining() returns accurate remaining request count
+        """
+        limiter = RateLimiter(window_seconds=60)
+        api_key = "test_key_123"
+        limit = 10
+
+        # Initial remaining should be limit
+        remaining = limiter.get_remaining(api_key, limit)
+        assert remaining == limit
+
+        # Make 3 requests
+        for i in range(3):
+            limiter.check_rate_limit(api_key, limit)
+
+        # Remaining should be 7
+        remaining = limiter.get_remaining(api_key, limit)
+        assert remaining == 7
+
+        # Make 7 more requests
+        for i in range(7):
+            limiter.check_rate_limit(api_key, limit)
+
+        # Remaining should be 0
+        remaining = limiter.get_remaining(api_key, limit)
+        assert remaining == 0
+
+    def test_reset_clears_specific_key(self):
+        """
+        Make requests, reset specific key, make more requests
+        Assert: reset() clears rate limit for specific key
+        """
+        limiter = RateLimiter(window_seconds=60)
+        api_key_1 = "test_key_1"
+        api_key_2 = "test_key_2"
+        limit = 3
+
+        # Exhaust both keys
+        for i in range(limit):
+            limiter.check_rate_limit(api_key_1, limit)
+            limiter.check_rate_limit(api_key_2, limit)
+
+        # Both should be limited
+        allowed_1, _ = limiter.check_rate_limit(api_key_1, limit)
+        allowed_2, _ = limiter.check_rate_limit(api_key_2, limit)
+        assert allowed_1 is False
+        assert allowed_2 is False
+
+        # Reset only key 1
+        limiter.reset(api_key_1)
+
+        # Key 1 should work, key 2 should still be limited
+        allowed_1, _ = limiter.check_rate_limit(api_key_1, limit)
+        allowed_2, _ = limiter.check_rate_limit(api_key_2, limit)
+        assert allowed_1 is True
+        assert allowed_2 is False
+
+    def test_reset_all_clears_all_keys(self):
+        """
+        Make requests with multiple keys, reset all, make more requests
+        Assert: reset() with no argument clears all keys
+        """
+        limiter = RateLimiter(window_seconds=60)
+        api_key_1 = "test_key_1"
+        api_key_2 = "test_key_2"
+        limit = 3
+
+        # Exhaust both keys
+        for i in range(limit):
+            limiter.check_rate_limit(api_key_1, limit)
+            limiter.check_rate_limit(api_key_2, limit)
+
+        # Reset all
+        limiter.reset()
+
+        # Both should work
+        allowed_1, _ = limiter.check_rate_limit(api_key_1, limit)
+        allowed_2, _ = limiter.check_rate_limit(api_key_2, limit)
+        assert allowed_1 is True
+        assert allowed_2 is True
+
+
+class TestRateLimitingEndToEnd:
+    """Test rate limiting through FastAPI endpoints (end-to-end tests)."""
+
+    def test_requests_under_limit_succeed(self, client, temp_data_dir, mock_memory_tools, reset_rate_limiter):
+        """
+        Make multiple requests under the rate limit
+        Assert: All requests return 200/201
+        """
+        # Setup database and API key with low limit for testing
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True,
+                "default_rate_limit": 100
+            }
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        api_key = key_manager.generate_key("test-key", rate_limit=10)
+
+        # Make 5 requests (under limit of 10)
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                for i in range(5):
+                    response = client.get(
+                        f"/api/v1/recall?query=test_{i}",
+                        headers={"X-API-Key": api_key}
+                    )
+                    assert response.status_code == 200, f"Request {i+1} should succeed"
+
+    def test_request_over_limit_returns_429_with_retry_after(self, client, temp_data_dir, mock_memory_tools, reset_rate_limiter):
+        """
+        Make requests exceeding the rate limit
+        Assert: Returns 429 with Retry-After header
+        """
+        # Setup database and API key with very low limit
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True,
+                "default_rate_limit": 3
+            }
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        api_key = key_manager.generate_key("test-key", rate_limit=3)
+
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                # Make 3 requests (should all succeed)
+                for i in range(3):
+                    response = client.get(
+                        f"/api/v1/recall?query=test_{i}",
+                        headers={"X-API-Key": api_key}
+                    )
+                    assert response.status_code == 200
+
+                # 4th request should be rate limited
+                response = client.get(
+                    "/api/v1/recall?query=test_over_limit",
+                    headers={"X-API-Key": api_key}
+                )
+
+                assert response.status_code == 429
+                assert "Retry-After" in response.headers
+                retry_after = int(response.headers["Retry-After"])
+                assert retry_after > 0
+                assert retry_after <= 60
+                assert "Rate limit exceeded" in response.json()["detail"]
+
+    def test_different_endpoints_share_same_rate_limit(self, client, temp_data_dir, mock_memory_tools, reset_rate_limiter):
+        """
+        Make requests to different endpoints with same API key
+        Assert: Rate limit is shared across all endpoints
+        """
+        # Setup database and API key with low limit
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True,
+                "default_rate_limit": 5
+            }
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        api_key = key_manager.generate_key("test-key", rate_limit=5)
+
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                # Make 2 recall requests
+                for i in range(2):
+                    response = client.get(
+                        f"/api/v1/recall?query=test_{i}",
+                        headers={"X-API-Key": api_key}
+                    )
+                    assert response.status_code == 200
+
+                # Make 3 store requests
+                for i in range(3):
+                    response = client.post(
+                        "/api/v1/store",
+                        json={"content": f"Test memory {i}", "memory_type": "fact"},
+                        headers={"X-API-Key": api_key}
+                    )
+                    assert response.status_code == 201
+
+                # 6th request (any endpoint) should be rate limited
+                response = client.get(
+                    "/api/v1/recall?query=should_fail",
+                    headers={"X-API-Key": api_key}
+                )
+                assert response.status_code == 429
+
+    def test_different_api_keys_have_separate_rate_limits(self, client, temp_data_dir, mock_memory_tools, reset_rate_limiter):
+        """
+        Make requests with different API keys
+        Assert: Each API key has independent rate limit
+        """
+        # Setup database and API keys
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True,
+                "default_rate_limit": 3
+            }
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        api_key_1 = key_manager.generate_key("test-key-1", rate_limit=3)
+        api_key_2 = key_manager.generate_key("test-key-2", rate_limit=3)
+
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                # Exhaust key 1's limit
+                for i in range(3):
+                    response = client.get(
+                        f"/api/v1/recall?query=test_{i}",
+                        headers={"X-API-Key": api_key_1}
+                    )
+                    assert response.status_code == 200
+
+                # Key 1 should be limited
+                response = client.get(
+                    "/api/v1/recall?query=should_fail",
+                    headers={"X-API-Key": api_key_1}
+                )
+                assert response.status_code == 429
+
+                # Key 2 should still work
+                for i in range(3):
+                    response = client.get(
+                        f"/api/v1/recall?query=test_key2_{i}",
+                        headers={"X-API-Key": api_key_2}
+                    )
+                    assert response.status_code == 200
+
+    def test_custom_rate_limits_per_key_work_correctly(self, client, temp_data_dir, mock_memory_tools, reset_rate_limiter):
+        """
+        Create API keys with different rate limits
+        Assert: Each key respects its configured limit
+        """
+        # Setup database and API keys with different limits
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True,
+                "default_rate_limit": 100
+            }
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        low_limit_key = key_manager.generate_key("low-limit-key", rate_limit=2)
+        high_limit_key = key_manager.generate_key("high-limit-key", rate_limit=10)
+
+        with patch('omi.rest_api.Path.home', return_value=temp_data_dir.parent.parent):
+            with patch('omi.rest_api.get_memory_tools', return_value=mock_memory_tools):
+                # Low limit key: make 2 requests (should succeed)
+                for i in range(2):
+                    response = client.get(
+                        f"/api/v1/recall?query=low_{i}",
+                        headers={"X-API-Key": low_limit_key}
+                    )
+                    assert response.status_code == 200
+
+                # Low limit key: 3rd request should fail
+                response = client.get(
+                    "/api/v1/recall?query=low_fail",
+                    headers={"X-API-Key": low_limit_key}
+                )
+                assert response.status_code == 429
+
+                # High limit key: make 10 requests (should all succeed)
+                for i in range(10):
+                    response = client.get(
+                        f"/api/v1/recall?query=high_{i}",
+                        headers={"X-API-Key": high_limit_key}
+                    )
+                    assert response.status_code == 200
+
+                # High limit key: 11th request should fail
+                response = client.get(
+                    "/api/v1/recall?query=high_fail",
+                    headers={"X-API-Key": high_limit_key}
+                )
+                assert response.status_code == 429
+
+    def test_rate_limit_does_not_apply_to_unauthenticated_endpoints(self, client, temp_data_dir, reset_rate_limiter):
+        """
+        Make many requests to unauthenticated endpoints
+        Assert: No rate limiting on root and health endpoints
+        """
+        # Setup database and API key
+        db_path = temp_data_dir / "palace.sqlite"
+        config_path = temp_data_dir / "config.yaml"
+
+        config_path.write_text(yaml.dump({
+            "security": {
+                "auth_required": True
+            }
+        }))
+
+        key_manager = APIKeyManager(db_path)
+        key_manager.generate_key("test-key", rate_limit=1)  # Very low limit
+
+        # Make many requests to root and health (should all succeed)
+        for i in range(10):
+            response = client.get("/")
+            assert response.status_code == 200
+
+            response = client.get("/health")
+            assert response.status_code == 200


### PR DESCRIPTION
Add API key authentication to all 16 REST API endpoints. Support both header-based (X-API-Key) and query parameter authentication. Include configurable rate limiting per API key. Provide a CLI command to generate and manage API keys. Authentication can be disabled for local development via config.